### PR TITLE
Fix class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 you can inject os update command to some docker images.
 
 ```ruby
-image = Pinject.new("ubuntu:latest")
+image = Pinject::Docker.new("ubuntu:latest")
 inject_image = image.inject_build("pyama:ubuntu_inject") # run apt-get upgrade
 inject_image.push
 ```


### PR DESCRIPTION
Pinject::Docker.newが正しそうです！

```
irb(main):002:0> image = Pinject.new("ubuntu:latest")
(irb):2:in `<main>': undefined method `new' for Pinject:Module (NoMethodError)
        from /home/ykky/.asdf/installs/ruby/3.1.0/lib/ruby/gems/3.1.0/gems/irb-1.4.1/exe/irb:11:in `<top (required)>'
        from /home/ykky/.asdf/installs/ruby/3.1.0/bin/irb:25:in `load'
        from /home/ykky/.asdf/installs/ruby/3.1.0/bin/irb:25:in `<main>'
irb(main):003:0> image = Pinject::Docker.new("ubuntu:latest")
=> #<Pinject::Docker:0x00007f16dab8e9d8 @image_name="ubuntu:latest", @log=false>
```