### PR TITLE
Use streaming_logs instead of thread

### DIFF
--- a/lib/pinject/docker.rb
+++ b/lib/pinject/docker.rb
@@ -51,9 +51,8 @@ module Pinject
                                              })
 
       result = nil
-      t = Thread.new { container.attach { |stream, chunk| result = chunk.chomp if stream == :stdout } }
       container.start
-      t.join
+      container.streaming_logs(stdout: true) { |stream, chunk| result = chunk.chomp if stream == :stdout }
 
       if result
         dist, version, user = result.split(%r{:|/})


### PR DESCRIPTION
コンテナによってはdetect_osがnilになってしまうので正しく取れるようにします！

```
❯ irb -rpinject
irb(main):001:0> Pinject::Docker.new("php:7.2.1").send(:detect_os)
=> nil
```

---
ちゃんと調べていないですが、Thread.newの中でputsとかをすると正しく取れるので、タイミングによってcontainer.attachができていなそうな感じがしてます。
streaming_logsを使うことでコンテナの出力を取れるようにしています。